### PR TITLE
Convert DeploymentConfig to Deployment

### DIFF
--- a/yaml/ucb-jenkins-persistent.yaml
+++ b/yaml/ucb-jenkins-persistent.yaml
@@ -69,15 +69,14 @@
 			"apiVersion": "v1",
 			"kind": "Deployment",
 			"metadata": {
-				"annotations": {
-					"template.alpha.openshift.io/wait-for-ready": "true"
-				},
 				"name": "${JENKINS_SERVICE_NAME}"
 			},
 			"spec": {
 				"replicas": 1,
 				"selector": {
-					"name": "${JENKINS_SERVICE_NAME}"
+					"matchLabels": {
+					  "app": "${JENKINS_SERVICE_NAME}"
+					}
 				},
 				"strategy": {
 					"type": "Recreate",
@@ -99,7 +98,7 @@
 				"template": {
 					"metadata": {
 						"labels": {
-							"name": "${JENKINS_SERVICE_NAME}"
+							"app": "${JENKINS_SERVICE_NAME}"
 						}
 					},
 					"spec": {
@@ -283,7 +282,7 @@
 					}
 				],
 				"selector": {
-					"name": "${JENKINS_SERVICE_NAME}"
+					"app": "${JENKINS_SERVICE_NAME}"
 				},
 				"sessionAffinity": "None",
 				"type": "ClusterIP"
@@ -310,7 +309,7 @@
 					}
 				],
 				"selector": {
-					"name": "${JENKINS_SERVICE_NAME}"
+					"app": "${JENKINS_SERVICE_NAME}"
 				},
 				"sessionAffinity": "None",
 				"type": "ClusterIP"


### PR DESCRIPTION
This PR has changes to convert the soon-to-be-depracated DeploymentConfig in the Jenkins template to a Deployment